### PR TITLE
docs: clarify canvas export in QuoteHolder

### DIFF
--- a/client/src/Components/QuoteHolder.js
+++ b/client/src/Components/QuoteHolder.js
@@ -1,7 +1,6 @@
 
 import bg from '../Assets/QGPhone.svg';
 import Quote from './Quote';
-import html2canvas from 'html2canvas';
 import { useDispatch } from 'react-redux';
 import { actions } from '../utils/Store';
 import QuoteCanvasPC from './QuoteCanvasPC';
@@ -15,17 +14,11 @@ const QuoteHolder = () => {
 
 
     const download = () => {
-
-     //  html2canvas(document.querySelector('#myQuote')).then((canvas) => {
-
-
-
-        let anchor = document.createElement('a');
+        // Export the quote canvas directly to a PNG image
+        const anchor = document.createElement('a');
         anchor.href = document.querySelector("#quoteCanvasPC").toDataURL('image/png');
         anchor.download = 'image.png';
         anchor.click();
-
-     //   })
     }
 
 


### PR DESCRIPTION
## Summary
- remove outdated html2canvas references in QuoteHolder
- document canvas-based image export

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896d005ed448320952ee32bb365bc2c