### PR TITLE
chore: guard debug console logs

### DIFF
--- a/client/src/Components/QuoteCanvas.js
+++ b/client/src/Components/QuoteCanvas.js
@@ -21,7 +21,9 @@ const QuoteCanvas = () => {
 
         setDimentions({width:divQuote.offsetWidth, height:divQuote.offsetHeight});
 
-        console.log(divQuote.width,"  ",divQuote.height)
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(divQuote.width, "  ", divQuote.height);
+        }
 
         const canvas = quote.current;
 

--- a/client/src/Components/QuoteCanvasPC.js
+++ b/client/src/Components/QuoteCanvasPC.js
@@ -21,7 +21,9 @@ const QuoteCanvasPC = () => {
 
         setDimentions({ width: divQuote.offsetWidth, height: divQuote.offsetHeight  });
 
-        console.log(divQuote.width, "  ", divQuote.height)
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(divQuote.width, "  ", divQuote.height);
+        }
 
         const canvas = quote.current;
 

--- a/client/src/Particles/Background.js
+++ b/client/src/Particles/Background.js
@@ -13,7 +13,9 @@ const Background = (props) => {
 
 
     const particlesInit = async (main) => {
-        console.log(main);
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(main);
+        }
 
         // you can initialize the tsParticles instance (main) here, adding custom shapes or presets
         // this loads the tsparticles package bundle, it's the easiest method for getting everything ready
@@ -22,7 +24,9 @@ const Background = (props) => {
     };
 
     const particlesLoaded = (container) => {
-        console.log(container);
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(container);
+        }
 
        
             dispatchAction(actions.loaded());


### PR DESCRIPTION
## Summary
- avoid console noise by wrapping debug logs with NODE_ENV checks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896d211816483208ac7623d13ac95d1