### PR TITLE
Refactor quote canvas to use refs

### DIFF
--- a/client/src/Components/Quote.js
+++ b/client/src/Components/Quote.js
@@ -1,8 +1,6 @@
-import { useEffect } from "react";
 import { useSelector } from "react-redux";
 
-
-const Quote = () => {
+const Quote = ({ quoteRef }) => {
 
     const color = useSelector(state => state.color);
 
@@ -13,28 +11,16 @@ const Quote = () => {
 
     const fontStyle = useSelector(state => state.fontStyle);
 
+    return (<div ref={quoteRef} id="myQuote" style={{ backgroundColor: color, color: fontColor,
+        fontFamily: fontStyle, width: '20vw', minHeight: 'auto', margin: 'auto' }} className="w3-display-container slide-in-top   w3-center  ">
+
+        <div dangerouslySetInnerHTML={{ __html: quote.replace(/\n/g, "<br>\n") }} style={{ paddingLeft: '0.5vw', paddingRight: '0.5vw', paddingTop: '10vh', fontSize: '2.2vw' }} className="w3-center"></div>
 
 
-
-
-
-
-
-    return (<div id="myQuote" style={{ backgroundColor:color, color:fontColor,
-        fontFamily: fontStyle, width:'20vw', minHeight:'auto',    margin:'auto'}} className="w3-display-container slide-in-top   w3-center  ">
-
-        <div dangerouslySetInnerHTML={{ __html: quote.replace(/\n/g, "<br>\n") }} style={{ paddingLeft: '0.5vw', paddingRight:'0.5vw', paddingTop: '10vh', fontSize:'2.2vw' }} className="w3-center"></div>
-        
-        
-        <div style={{ marginTop: '5vh', paddingBottom: '10vh', fontSize:'1.2vw' }} className="">- {signature }</div>
-
-
+        <div style={{ marginTop: '5vh', paddingBottom: '10vh', fontSize: '1.2vw' }} className="">- {signature }</div>
 
 
     </div>);
-
-
 }
-
 
 export default Quote;

--- a/client/src/Components/QuoteCanvas.js
+++ b/client/src/Components/QuoteCanvas.js
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import canvasTxt from 'canvas-txt';
 
 
-const QuoteCanvas = () => {
+const QuoteCanvas = ({ containerRef }) => {
 
     const color = useSelector(state => state.color);
     const fontColor = useSelector(state => state.fontColor);
@@ -17,11 +17,10 @@ const QuoteCanvas = () => {
     useEffect(() => {
 
 
-        const divQuote = document.getElementById('myQuotePhone');
-
-        setDimentions({width:divQuote.offsetWidth, height:divQuote.offsetHeight});
-
-        console.log(divQuote.width,"  ",divQuote.height)
+        if (containerRef.current) {
+            setDimentions({width:containerRef.current.offsetWidth, height:containerRef.current.offsetHeight});
+            console.log(containerRef.current.offsetWidth,"  ",containerRef.current.offsetHeight)
+        }
 
         const canvas = quote.current;
 
@@ -56,7 +55,7 @@ const QuoteCanvas = () => {
 
 
 
-    },[color, fontStyle, fontColor, canvasDimentions]);
+    },[color, fontStyle, fontColor, canvasDimentions, containerRef]);
 
     
 

--- a/client/src/Components/QuoteCanvasPC.js
+++ b/client/src/Components/QuoteCanvasPC.js
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import canvasTxt from 'canvas-txt';
 
 
-const QuoteCanvasPC = () => {
+const QuoteCanvasPC = ({ containerRef }) => {
 
     const color = useSelector(state => state.color);
     const fontColor = useSelector(state => state.fontColor);
@@ -17,11 +17,10 @@ const QuoteCanvasPC = () => {
     useEffect(() => {
 
 
-        const divQuote = document.getElementById('myQuote');
-
-        setDimentions({ width: divQuote.offsetWidth, height: divQuote.offsetHeight  });
-
-        console.log(divQuote.width, "  ", divQuote.height)
+        if (containerRef.current) {
+            setDimentions({ width: containerRef.current.offsetWidth, height: containerRef.current.offsetHeight  });
+            console.log(containerRef.current.offsetWidth, "  ", containerRef.current.offsetHeight)
+        }
 
         const canvas = quote.current;
 
@@ -55,7 +54,7 @@ const QuoteCanvasPC = () => {
 
 
 
-    }, [color, fontStyle, fontColor, canvasDimentions]);
+    }, [color, fontStyle, fontColor, canvasDimentions, containerRef]);
 
 
 

--- a/client/src/Components/QuoteHolder.js
+++ b/client/src/Components/QuoteHolder.js
@@ -2,6 +2,7 @@
 import bg from '../Assets/QGPhone.svg';
 import Quote from './Quote';
 import { useDispatch } from 'react-redux';
+import { useRef } from 'react';
 import { actions } from '../utils/Store';
 import QuoteCanvasPC from './QuoteCanvasPC';
 
@@ -9,8 +10,8 @@ const QuoteHolder = () => {
 
 
     const storeDispatcher = useDispatch();
-     
-    
+    const quoteRef = useRef(null);
+
 
 
     const download = () => {
@@ -31,7 +32,7 @@ const QuoteHolder = () => {
         className=" w3-container w3-card-4 w3-round-xlarge">
         <br />
 
-        <Quote/> <QuoteCanvasPC/>
+        <Quote quoteRef={quoteRef} /> <QuoteCanvasPC containerRef={quoteRef} />
 
         <div style={{ fontFamily: 'Inder', width: '90%', margin: '0 auto' }} className="w3-bar">
             <br />
@@ -51,3 +52,4 @@ const QuoteHolder = () => {
 
 
 export default QuoteHolder;
+

--- a/client/src/Components/QuoteHolderPhone.js
+++ b/client/src/Components/QuoteHolderPhone.js
@@ -2,15 +2,16 @@
 import bg from '../Assets/QGPhone.svg';
 import html2canvas from 'html2canvas';
 import { useDispatch, useSelector } from 'react-redux';
+import { useRef } from 'react';
 import { actions } from '../utils/Store';
 import QuotePhone from './QuotePhone';
 import domtoimage from 'dom-to-image';
 import QuoteCanvas from './QuoteCanvas';
+
 const QuoteHolderPhone = () => {
 
-
     const storeDispatcher = useDispatch();
-
+    const quoteRef = useRef(null);
     const color = useSelector(state => state.color);
 
     const downloadPhone = () => {
@@ -76,7 +77,7 @@ const QuoteHolderPhone = () => {
         className=" w3-container w3-card-4 w3-round-xlarge">
         <br />
 
-        <QuotePhone /> <QuoteCanvas/>
+        <QuotePhone quoteRef={quoteRef} /> <QuoteCanvas containerRef={quoteRef} />
 
         <div style={{ fontFamily: 'Inder', width: '90%', margin: '0 auto' }} className="w3-bar">
             <br />

--- a/client/src/Components/QuotePhone.js
+++ b/client/src/Components/QuotePhone.js
@@ -1,9 +1,8 @@
-import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import fonts from "../utils/fonts";
 
 
-const QuotePhone = () => {
+const QuotePhone = ({ quoteRef }) => {
 
     const color = useSelector(state => state.color);
 
@@ -24,7 +23,7 @@ const QuotePhone = () => {
 
 
 
-  return (<div id="myQuotePhone" style={{
+  return (<div ref={quoteRef} id="myQuotePhone" style={{
         backgroundColor: color, color: fontColor,
         fontFamily: fontStyle, width: '90vw', minHeight: 'auto', margin: 'auto'
     }} className=" slide-in-bottom   w3-center  ">


### PR DESCRIPTION
## Summary
- pass refs from holders to quote components and canvas
- read quote dimensions from the passed refs instead of document.getElementById

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2158d04832092440041397559eb