### PR TITLE
refactor: reuse dispatch in quote generators

### DIFF
--- a/client/src/Components/QuoteGeneratorPC.js
+++ b/client/src/Components/QuoteGeneratorPC.js
@@ -13,8 +13,7 @@ const QuoteGeneratorPC = () => {
     const signature = useSelector(state => state.signature);
 
 
-    const quoteAndSignDispatcher = useDispatch();
-    const displayQuoteDispatcher = useDispatch();
+    const dispatch = useDispatch();
 
     return (<div style={{ margin: 'auto', maxWidth: '40%', minHeight: '40%', backgroundImage: `url(${bg})`, backgroundSize: 'cover' }}
         className=" w3-container w3-card-4 w3-round-xlarge">
@@ -34,12 +33,12 @@ const QuoteGeneratorPC = () => {
 
                     () => {
 
-                        quoteAndSignDispatcher(actions.setQuoteAndSign({
+                        dispatch(actions.setQuoteAndSign({
                             quote: quote.current.value,
                             signature: sign.current.value
                         }));
 
-                        displayQuoteDispatcher(actions.showQuote());
+                        dispatch(actions.showQuote());
                     }
 
 

--- a/client/src/Components/QuoteGeneratorPhone.js
+++ b/client/src/Components/QuoteGeneratorPhone.js
@@ -6,14 +6,13 @@ const QuoteGeneratorPhone = () => {
 
     const quote = useRef();
     const sign = useRef();
- 
+
 
     const myQuote = useSelector(state => state.quote);
     const signature = useSelector(state => state.signature);
 
 
-    const quoteAndSignDispatcher = useDispatch();
-    const displayQuoteDispatcher = useDispatch();
+    const dispatch = useDispatch();
 
     
 
@@ -41,12 +40,12 @@ const QuoteGeneratorPhone = () => {
 
                 () => {
 
-                    quoteAndSignDispatcher(actions.setQuoteAndSign({
+                    dispatch(actions.setQuoteAndSign({
                         quote: quote.current.value,
                         signature: sign.current.value
                     }));
-                   
-                    displayQuoteDispatcher(actions.showQuote());
+
+                    dispatch(actions.showQuote());
                 }
 
 


### PR DESCRIPTION
## Summary
- simplify QuoteGeneratorPC to invoke useDispatch once and reuse the dispatch variable
- simplify QuoteGeneratorPhone to invoke useDispatch once and reuse the dispatch variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896d22df67483208dd673b9364d52c1