### PR TITLE
Resolve merge conflicts and stabilize tests

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
 import App from './App';
+import store from './utils/Store';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders header', () => {
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+  const headerElement = screen.getByText(/Quote Cards/i);
+  expect(headerElement).toBeInTheDocument();
 });

--- a/client/src/Components/QuoteGeneratorPhone.js
+++ b/client/src/Components/QuoteGeneratorPhone.js
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import bg from '../Assets/QGPhone.svg';
 import { actions } from '../utils/Store';

--- a/client/src/Components/QuoteHolderPhone.js
+++ b/client/src/Components/QuoteHolderPhone.js
@@ -1,18 +1,14 @@
-
 import bg from '../Assets/QGPhone.svg';
-import html2canvas from 'html2canvas';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useRef } from 'react';
 import { actions } from '../utils/Store';
 import QuotePhone from './QuotePhone';
-import domtoimage from 'dom-to-image';
 import QuoteCanvas from './QuoteCanvas';
 
 const QuoteHolderPhone = () => {
 
     const storeDispatcher = useDispatch();
     const quoteRef = useRef(null);
-    const color = useSelector(state => state.color);
 
     const downloadPhone = () => {
 

--- a/client/src/Components/QuotePhone.js
+++ b/client/src/Components/QuotePhone.js
@@ -1,6 +1,4 @@
 import { useSelector } from "react-redux";
-import fonts from "../utils/fonts";
-
 
 const QuotePhone = ({ quoteRef }) => {
 

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+jest.mock('use-mediaquery', () => () => false);


### PR DESCRIPTION
## Summary
- remove leftover imports from phone components
- mock `use-mediaquery` and wrap `App` in Redux provider for testing
- tidy phone quote holder logic

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6896d49a28c0832092496a71c3e22693